### PR TITLE
fix hashCode calculation for negative and non latin 1 seeds

### DIFF
--- a/cutil.h
+++ b/cutil.h
@@ -2,6 +2,7 @@
 #define CUTIL_H
 
 #include <QMutex>
+#include <QString>
 
 #include <random>
 
@@ -171,25 +172,29 @@ static inline int64_t getRnd64()
 }
 
 enum { S_TEXT, S_NUMERIC, S_RANDOM };
-inline int str2seed(const char *str, int64_t *out)
+inline int str2seed(const QString &str, int64_t *out)
 {
-    int slen = strlen(str);
-    char *p;
-    if (slen == 0)
+    if (str.isEmpty())
     {
         *out = getRnd64();
         return S_RANDOM;
     }
 
-    *out = strtoll(str, &p, 10);
-    if (str + slen == p)
+    bool ok = false;
+    *out = str.toLong(&ok);
+    if (ok)
+    {
         return S_NUMERIC;
+    }
 
     // String.hashCode();
-    *out = 0;
-    for (int i = 0; i < slen; i++)
-        *out = 31*(*out) + str[i];
-    *out &= (uint32_t)-1;
+    int32_t hash = 0;
+    const ushort *chars = str.utf16();
+    for (int i = 0; chars[i] != 0; i++)
+    {
+        hash = 31 * hash + chars[i];
+    }
+    *out = hash;
     return S_TEXT;
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -120,8 +120,7 @@ bool MainWindow::getSeed(int *mc, int64_t *seed, bool applyrand)
 
     if (seed)
     {
-        const QByteArray& ba = ui->seedEdit->text().toLocal8Bit();
-        int v = str2seed(ba.data(), seed);
+        int v = str2seed(ui->seedEdit->text(), seed);
         if (applyrand && v == S_RANDOM)
             ui->seedEdit->setText(QString::asprintf("%" PRId64, *seed));
     }
@@ -300,7 +299,7 @@ void MainWindow::on_seedEdit_editingFinished()
 void MainWindow::on_seedEdit_textChanged(const QString &a)
 {
     int64_t s;
-    int v = str2seed(a.toLocal8Bit().data(), &s);
+    int v = str2seed(a, &s);
     switch (v)
     {
         case 0: ui->labelSeedType->setText("(text)"); break;

--- a/quadlistdialog.cpp
+++ b/quadlistdialog.cpp
@@ -62,8 +62,7 @@ bool QuadListDialog::getSeed(int *mc, int64_t *seed)
         return false;
     }
 
-    const QByteArray& ba = ui->lineSeed->text().toLocal8Bit();
-    int v = str2seed(ba.data(), seed);
+    int v = str2seed(ui->lineSeed->text(), seed);
     if (v == S_RANDOM)
         ui->lineSeed->setText(QString::asprintf("%" PRId64, *seed));
 


### PR DESCRIPTION
The existing calculation was incorrect because `*out &= (uint32_t)-1;` is not the same as `*out = (int32_t) *out;` for negative numbers, and it also incorrectly converted to UTF-8, where hashCode should be calculated on UTF-16 code units