### PR TITLE
Limit zoom

### DIFF
--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -224,8 +224,10 @@ void MapView::resizeEvent(QResizeEvent *e)
 void MapView::wheelEvent(QWheelEvent *e)
 {
     const qreal ang = e->angleDelta().y() / 8; // e->delta() / 8;
-    blocks2pix *= pow(2, ang/100);
-    update();//repaint();
+    if (blocks2pix > 0.001 || ang > 0) {
+        blocks2pix *= pow(2, ang/100);
+        update();//repaint();
+    }
 }
 
 void MapView::mousePressEvent(QMouseEvent *e)


### PR DESCRIPTION
While playing around I found out that cubiomes-viewer allows infinity zooming out. If you zoom out too much, it will hang. When you close cubiomes-viewer, it will try to load the session and hang, which is a really bad user experience. SO it's the best to limit the zoom factor.