### PR TITLE
add qt5-linguist dependency to buildguide

### DIFF
--- a/buildguide.md
+++ b/buildguide.md
@@ -46,7 +46,7 @@ $ sudo apt install build-essential qt5-default
 ```
 ##### Fedora
 ```
-$ sudo dnf install qt5-qtbase-devel
+$ sudo dnf install qt5-qtbase-devel qt5-linguist
 ```
 ##### macOS
 ```


### PR DESCRIPTION
This PR adds a dependency needed to build on fedora to the buildguide.