### PR TITLE
[Linux]Show progress in window icon

### DIFF
--- a/cubiomes-viewer.pro
+++ b/cubiomes-viewer.pro
@@ -229,4 +229,7 @@ with_network: {
     HEADERS += src/updater.h
 }
 
-
+with_dbus: {
+    QT += dbus
+    DEFINES += "WITH_DBUS=1"
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
     }
     else
     {
+        QGuiApplication::setDesktopFileName("com.github.cubitect.cubiomes-viewer");
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
         QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
         QApplication::setAttribute(Qt::AA_UseStyleSheetPropagationInWidgetStyles, false);


### PR DESCRIPTION
This shows the current progress in the window icon on Linux. It is not supported by every desktop. You can use KDE if you want to test it. Cubiomes Viewer must be installed to make this work.

![Screenshot_20240205_085801](https://github.com/Cubitect/cubiomes-viewer/assets/15185051/4b7d479c-b145-42ed-9718-976d2b168b71)

This is also possible under Windows, but I don't know how it works there.
